### PR TITLE
Allow empty inserts for ModuleEngagementSummaryMetricRangesMysqlTask

### DIFF
--- a/edx/analytics/tasks/insights/module_engagement.py
+++ b/edx/analytics/tasks/insights/module_engagement.py
@@ -766,6 +766,10 @@ class ModuleEngagementSummaryMetricRangesMysqlTask(ModuleEngagementDownstreamMix
                     'want.',
         significant=False
     )
+    allow_empty_insert = luigi.BooleanParameter(
+        default=False,
+        config_path={'section': 'module-engagement', 'name': 'allow_empty_insert'},
+    )
 
     @property
     def table(self):


### PR DESCRIPTION
Cherry picked from commit df055d869b98480c68e5a0b2b1923d3f51846443. See upstream PR: https://github.com/edx/edx-analytics-pipeline/pull/446

This fixes the following error:
```
2018-02-26 15:44:03,707 ERROR 15890 [luigi-interface] worker.py:304 - [pid 15890] Worker Worker(salt=601911619, host=ip-172-1-1-1, username=hadoop, pid=15890) failed    ModuleEngagementSummaryMetricRangesMysqlTask(source=('s3://edxapp-rue89-logs/logs/tracking/',), expand_interval=30 days, 0:00:00, pattern=('.*tracking.log-(?P<date>[0-9]+).*',), date_pattern=%Y%m%d, database=reports, credentials=s3://edxanalytics-rue89-lib/edxanalytics_creds, warehouse_path=s3://edxanalytics-rue89-hadoop/warehouse/hive/, date=2018-02-26)
Traceback (most recent call last):
  File "/var/lib/analytics-tasks/automation/venv/local/lib/python2.7/site-packages/luigi/worker.py", line 292, in _run_task
    task.run()
  File "/var/lib/analytics-tasks/automation/venv/local/lib/python2.7/site-packages/edx/analytics/tasks/common/mysql_load.py", line 332, in run
    self.insert_rows(cursor)
  File "/var/lib/analytics-tasks/automation/venv/local/lib/python2.7/site-packages/edx/analytics/tasks/common/mysql_load.py", line 302, in insert_rows
    raise Exception('Cannot overwrite a table with an empty result set.')
Exception: Cannot overwrite a table with an empty result set.
```